### PR TITLE
Agregando margin-left a los iconos del sidenav

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -17,12 +17,15 @@
 .sidenav-btn {
   width: 100%;
   padding: 1%;
-  margin-left: 2%;
   text-align: left;
 }
 
 mat-drawer {
   width: 50%;
+}
+
+mat-icon {
+  margin-left: 2%;
 }
 
 /* Medium devices (tablets, 768px and up) */


### PR DESCRIPTION
Agregué margin left a los iconos del sidenav, se los había aplicado a los botones, pero no se veía bien ya que no estaba ocupando todo el ancho, en cambio, se los apliqué a los iconos y ahora sí se ve que los botones tengan su 100% de ancho, además, no está pegado a la izquierda, tiene un espacio como en el diseño.